### PR TITLE
Implement the package name specifying

### DIFF
--- a/test/Utils/ThankYouStars/PackageSpec.hs
+++ b/test/Utils/ThankYouStars/PackageSpec.hs
@@ -32,6 +32,7 @@ spec = do
                 , "hackage-db"
                 , "hspec"
                 , "req"
+                , "safe"
                 , "split"
                 , "text"
                 , "thank-you-stars"

--- a/thank-you-stars.cabal
+++ b/thank-you-stars.cabal
@@ -30,6 +30,7 @@ library
                      , filepath
                      , hackage-db
                      , req
+                     , safe
                      , split
                      , text
   default-language:    Haskell2010


### PR DESCRIPTION
I have this project :smile:

- [hs-zuramaru](https://github.com/aiya000/hs-zuramaru)

But the package name of this is 'zuramaru' (not 'hs-zuramaru').

This PR allows to

```console
$ cd hs-zuramaru
$ thank-you-stars zuramaru
(works correctly)
```
